### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/Web/wwwroot/vendors/jquery-ui/jquery-ui.js
+++ b/Web/wwwroot/vendors/jquery-ui/jquery-ui.js
@@ -17588,7 +17588,7 @@ $.widget( "ui.tabs", {
 	},
 
 	_sanitizeSelector: function( hash ) {
-		return hash ? hash.replace( /[!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g, "\\$&" ) : "";
+		return hash ? hash.replace(/[!"$%&'()*+,.\/:;<=>?@[\\\]\^`{|}~]/g, "\\$&") : "";
 	},
 
 	refresh: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/amitdole/nakshatra/security/code-scanning/3](https://github.com/amitdole/nakshatra/security/code-scanning/3)

To fix the issue, we need to modify the regular expression in the `_sanitizeSelector` function to include backslashes (`\`) in the set of characters to be escaped. This can be done by adding `\\` to the character set in the regular expression. The updated regular expression will escape all special characters, including backslashes, by prefixing them with a backslash.

The updated function will look like this:
```javascript
_sanitizeSelector: function( hash ) {
    return hash ? hash.replace(/[!"$%&'()*+,.\/:;<=>?@[\\\]\^`{|}~]/g, "\\$&") : "";
}
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
